### PR TITLE
Update update-help-support-link and text README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are upgrading from the ParkTAG SDK v2.2 or lower, please make sure that y
 Look through the [FAQ](https://github.com/predict-io/PredictIO-Android/wiki/FAQ) for answers to the most commonly-asked questions about predict.io.
 
 ## Communication 
-If you need help, visit our [Support Center] (http://www.predict.io/support-center/)
+If you need help, visit our [Help Center] (https://support.predict.io)
 
 ## Author
 predict.io, support@predict.io


### PR DESCRIPTION
Renamed "support center” to “Help Center” and changed link to https://support.predict.io
